### PR TITLE
Add Gigabyte BPCE-3350C to devices affected by MSI OEM key leak

### DIFF
--- a/MSI/IntelOemKeyImpactedDevices.md
+++ b/MSI/IntelOemKeyImpactedDevices.md
@@ -43,3 +43,11 @@ iAPLx-DE(TAA30 TEST)
 ```
 flt2
 ```
+
+### Affected Gigabyte (APL) products:
+
+```
+GB-BPCE-3350C (rev. 1.0)
+GB-EAPD-4200 (rev. 1.0)
+MZAPLAI (rev. 1.0)
+```


### PR DESCRIPTION
The key has been see in the wild:
https://twitter.com/garnichtsoboese/status/1656961251052748801

Confirmed on upgrade image GB-BPCE-3350C_F12:
https://www.gigabyte.com/Mini-PcBarebone/GB-BPCE-3350C-rev-10/support#support-dl-bios
